### PR TITLE
added tick-by and tick-to methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,33 @@ Processing lazy sequences with progress:
         done))
 ```
 
+## Other ticking methods
+
+`clj-progress` also provides two extra tick methods:
+
+ * `(tick-by n)` - will tick by an amount of `n`
+ * `(tick-to x)` - will set current progress value as `x`
+ 
+### Examples
+
+```Clojure
+(use 'clj-progress.core)
+(use 'clojure.java.io)
+
+(let [input-path "in.txt"]
+  (init (-> (file input-path) .length))
+  (with-open [input (input-stream input-path)
+              output (output-stream "out.txt")]
+    (let [buffer (make-array Byte/TYPE 1024)]
+      (loop []
+        (let [size (.read input buffer)]
+          (when (pos? size)
+            (.write output buffer 0 size)
+            (tick-by size)
+            (recur))))))
+  (done))
+```
+
 ## Customizing progress bar
 
 You can customize progress bar using `set-progress-bar!` and `config-progress-bar!` methods.

--- a/src/clj_progress/core.clj
+++ b/src/clj_progress/core.clj
@@ -37,6 +37,16 @@
   (handle :tick)
   obj)
 
+(defn tick-by [n & [obj]]
+  (swap! *progress-state* update-in [:done] (partial + n))
+  (handle :tick)
+  obj)
+
+(defn tick-to [x & [obj]]
+  (swap! *progress-state* assoc-in [:done] x)
+  (handle :tick)
+  obj)
+
 (defn done [& [obj]]
   (handle :done)
   (reset! *progress-state* {})


### PR DESCRIPTION
Hi,

I was using the library and I missed some methods to set the progress in a more customized way (just the regular tick is not flexible enough for some cases).

So to improve that I added `tick-by` and `tick-to` methods that allow for custom incremental and custom direct setting of the progress.

I added an example using the `tick-by` which a think is great for using with stuff like stream progress. I didn't added an example for `tick-to` but I actually have a real use case for it, if you wanna check see this issue on `clj-http`: https://github.com/dakrone/clj-http/issues/219

Thanks
