### PR TITLE
Throttling Progress Bar Updates?

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Indeterminable state also change `:bar` animation.
 
 ## Throttling
 
-By default, `clj-progress` limits the frequency of progress bar updates. Default configuretion allows at most one update per every `20` milliseconds (maximum `50` updated per second).
+`clj-progress` limits the frequency of progress bar updates. Default configuration allows at most one update per every `20` milliseconds (maximum `50` updated per second).
 
 `clj-progress` will execute `:tick` progress handler (reprint progress bar, or invoke user-defined handler) as soon as you'll call any `tick` method for the first time.
 If you'll call it again any number of times during the wait period, `:tick` progress handler will not be executed, though progress status will be tracked internally.

--- a/README.md
+++ b/README.md
@@ -198,6 +198,24 @@ When progress state is indeterminable, following `progress-bar` tokens will be r
 
 Indeterminable state also change `:bar` animation.
 
+## Throttling
+
+By default, `clj-progress` limits the frequency of progress bar updates. Default configuretion allows at most one update per every `20` milliseconds (maximum `50` updated per second).
+
+`clj-progress` will execute `:tick` progress handler (reprint progress bar, or invoke user-defined handler) as soon as you'll call any `tick` method for the first time.
+If you'll call it again any number of times during the wait period, `:tick` progress handler will not be executed, though progress status will be tracked internally.
+
+You could change default behavior using `set-throttling!` function and `with-throttling` macro:
+
+```Clojure
+(set-throttling! wait-time-in-milliseconds)
+
+(with-throttling wait-time-in-milliseconds
+  (do-something))
+```
+
+Any non-positive value will completely disable throttling.
+
 ## Using custom progress handlers
 
 `clj-proggress` allows you to use your own progress handler by defining `:init`, `:tick` and `:done` hooks:

--- a/src/clj_progress/bar.clj
+++ b/src/clj_progress/bar.clj
@@ -40,12 +40,11 @@
   (-> ttl (/ done) (- 1) (* elapsed) long))
 
 (defn- update-progress-bar
-  [fmt options done? {:keys [header start ttl done ticks]}]
+  [fmt options done? {:keys [header start update ttl done ticks]}]
   (let [ttl?    (pos? ttl)
         percent (if ttl? (-> done (/ ttl) (* 100)))
         opts    (merge *progress-bar-options* options)
-        now     (. System (nanoTime))
-        elapsed (-> now (- start) (/ 1000000000))]
+        elapsed (-> update (- start) (/ 1000000000))]
     (print
       (sreplace (str "\r" fmt "     ")
         :header   header

--- a/src/clj_progress/core.clj
+++ b/src/clj_progress/core.clj
@@ -98,7 +98,7 @@
   (alter-var-root #'*progress-bar-options* merge options))
 
 (defmacro with-throttle [wait & body]
-  `(binding [*throttle* wait]
+  `(binding [*throttle* ~wait]
      ~@body))
 
 (defn set-throttle! [wait]

--- a/src/clj_progress/core.clj
+++ b/src/clj_progress/core.clj
@@ -96,3 +96,11 @@
 
 (defn config-progress-bar! [& {:as options}]
   (alter-var-root #'*progress-bar-options* merge options))
+
+(defmacro with-throttle [wait & body]
+  `(binding [*throttle* wait]
+     ~@body))
+
+(defn set-throttle! [wait]
+  (alter-var-root #'*throttle*
+                  (constantly wait)))

--- a/src/clj_progress/core.clj
+++ b/src/clj_progress/core.clj
@@ -6,7 +6,7 @@
 (def ^:dynamic *progress-handler*
   (progress-bar ":header [:bar] :percent :done/:total"))
 
-(def ^:dynamic *throttle* 1000)
+(def ^:dynamic *throttle* 20)
 
 (defn- handle [action]
   (if-let [f (get *progress-handler* action)]

--- a/test/clj_progress/bar_test.clj
+++ b/test/clj_progress/bar_test.clj
@@ -5,10 +5,10 @@
 
 (defn get-state
   [[header elapsed ttl done ticks]]
-  (let [now   (. System (nanoTime))
-        start (- now (* elapsed 1000000000))]
-    (zipmap [:header :start :ttl :done :ticks ]
-            [ header  start  ttl  done  ticks ])))
+  (let [update  (System/nanoTime)
+        start   (- update (* elapsed 1000000000))]
+    (zipmap [:header :start :ttl :done :ticks :update ]
+            [ header  start  ttl  done  ticks  update ])))
 
 (deftest test-progress-bar
   (are [fmt args res]
@@ -96,8 +96,9 @@
         n   5000
         s   (with-out-str
               (with-progress-bar fmt
-                (init n)
-                (dorun (pmap tick (range n)))
-                (done)))]
+                (with-throttle 0
+                  (init n)
+                  (dorun (pmap tick (range n)))
+                  (done))))]
     (is (<= n (re-count (str "\r" fmt) s)))
     (is (=  0 (re-count "\r\r" s)))))

--- a/test/clj_progress/core_test.clj
+++ b/test/clj_progress/core_test.clj
@@ -81,8 +81,9 @@
       (binding [*progress-handler*  {:tick (fn [_] (swap! c inc))}
                 *progress-state*    (atom {})]
         (init h n)
-        (dotimes [_ nticks]
-          (apply tick args))
+        (with-throttle 0
+          (dotimes [_ nticks]
+            (apply tick args)))
         (let [{:keys [ttl done ticks header]} @*progress-state*]
           (and  (= ttl n)
                 (= done @c ticks nticks)
@@ -98,8 +99,9 @@
       (binding [*progress-handler*  {:tick (fn [_] (swap! c inc))}
                 *progress-state*    (atom {})]
         (init h n)
-        (doseq [by bys]
-          (apply tick-by by args))
+        (with-throttle 0
+          (doseq [by bys]
+            (apply tick-by by args)))
         (let [{:keys [ttl done ticks header]} @*progress-state*]
           (and  (= ttl n)
                 (= done res)
@@ -119,8 +121,9 @@
       (binding [*progress-handler*  {:tick (fn [_] (swap! c inc))}
                 *progress-state*    (atom {})]
         (init h n)
-        (doseq [to tos]
-          (apply tick-to to args))
+        (with-throttle 0
+          (doseq [to tos]
+            (apply tick-to to args)))
         (let [{:keys [ttl done ticks header]} @*progress-state*]
           (and  (= ttl n)
                 (= done res)
@@ -164,14 +167,15 @@
                     (is (= -state expected-state))))]
     (binding [*progress-handler*  handler
               *progress-state*    state]
-      (init 10)
-      (check :init @state)
-      (tick)
-      (check :tick @state)
-      (tick-by 2)
-      (check :tick @state)
-      (tick-to 9)
-      (check :tick @state)
+      (with-throttle 0
+        (init 10)
+        (check :init @state)
+        (tick)
+        (check :tick @state)
+        (tick-by 2)
+        (check :tick @state)
+        (tick-to 9)
+        (check :tick @state))
       (let [-state @state]
         (done)
         (check :done -state)))))


### PR DESCRIPTION
Progress is updated at every tick. If I have a million ticks that can flow by in 60 seconds, there is an opportunity to conserve resources by throttling the updates, i.e. update the progress indicator no more frequently than say 25 or 50 times per second.

Well heck, while I was waiting I went ahead and created the [progress-light](https://github.com/Bill/progress-light) lib.