### PR TITLE
NullPointerException when passing lazy seq to core.done

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ When the third argument is provided, `init` returns it.
 
 `tick` and `done` takes no arguments, returning the first argument if any provided.
 
+If the first argument to `done` is an unrealized lazy sequence, then `done` will return new lazy sequence which will automatically call `done` function upon its realization.
+
 ### Examples
 
 ```Clojure
@@ -109,16 +111,17 @@ Processing lazy sequences with progress:
         done))
 ```
 
-Note that `done` should only be called after the lazy sequence is evaluated.
-It resets the state of the progress bar, making later `tick` calls illegal.
-Evaluate lazy sequences before calling `done`:
+Calling `done` with unrealized lazy sequence:
 
 ```Clojure
-(->> (range 1 50)
-     (init "Processing")
-     (map (comp tick process-item))
-     doall
-     done)
+(defn very-lazy []
+  (let [s (->>  (iterate inc 0)
+                (init "Processing" 50)
+                (map (comp tick process-item))
+                (take 50)
+                done)]
+    (println "Nothing happened yet")
+    (reduce + s)))
 ```
 
 ## Other ticking methods

--- a/src/clj_progress/core.clj
+++ b/src/clj_progress/core.clj
@@ -76,7 +76,7 @@
 (defn done [& [obj]]
   (if (and (instance? clojure.lang.LazySeq obj)
            (not (realized? obj)))
-      (lazy-cat obj (done*))
+      (lazy-cat obj (done* nil))
       (done* obj)))
 
 (defmacro with-progress [& body]

--- a/src/clj_progress/core.clj
+++ b/src/clj_progress/core.clj
@@ -68,10 +68,16 @@
   (swap! *progress-state* assoc-in [:done] x)
   (tick* obj))
 
-(defn done [& [obj]]
+(defn done* [obj]
   (handle :done)
   (reset! *progress-state* {})
   obj)
+
+(defn done [& [obj]]
+  (if (and (instance? clojure.lang.LazySeq obj)
+           (not (realized? obj)))
+      (lazy-cat obj (done*))
+      (done* obj)))
 
 (defmacro with-progress [& body]
   "Executes body incapsulating its progress"

--- a/test/clj_progress/core_test.clj
+++ b/test/clj_progress/core_test.clj
@@ -31,7 +31,8 @@
     [     [2]     ]
     [     (list 2)]
     [     #{2}    ]
-    [     {:q 2}  ]))
+    [     {:q 2}  ]
+    [     (range 7)]))
 
 
 (deftest test-init
@@ -186,15 +187,25 @@
                                     :done (ainc c3) }
               *progress-state*    (atom {})]
       (with-throttle 0
+        (->> (range 25)
+             (init "Processing")
+             (map tick)
+             dorun
+             done))
+      (is (= @*progress-state* {}))
+      (is (= @c1 1 ))
+      (is (= @c2 25))
+      (is (= @c3 1 ))
+      (with-throttle 0
         (->> (range 50)
              (init "Processing")
              (map tick)
              done
              dorun))
       (is (= @*progress-state* {}))
-      (is (= @c1 1 ))
-      (is (= @c2 50))
-      (is (= @c3 1 )))))
+      (is (= @c1 2 ))
+      (is (= @c2 75))
+      (is (= @c3 2 )))))
 
 
 (deftest test-hooks

--- a/test/clj_progress/core_test.clj
+++ b/test/clj_progress/core_test.clj
@@ -172,6 +172,26 @@
     [ ]))
 
 
+(deftest test-lazy
+  (let [c1 (atom 0)
+        c2 (atom 0)
+        c3 (atom 0)]
+    (binding [*progress-handler*  { :init (fn [_] (swap! c1 inc))
+                                    :tick (fn [_] (swap! c2 inc))
+                                    :done (fn [_] (swap! c3 inc)) }
+              *progress-state*    (atom {})]
+      (with-throttle 0
+        (->> (range 50)
+             (init "Processing")
+             (map tick)
+             done
+             dorun))
+      (is (= @*progress-state* {}))
+      (is (= @c1 1 ))
+      (is (= @c2 50))
+      (is (= @c3 1 )))))
+
+
 (deftest test-hooks
   (let [state   (atom {})
         log     (atom [])

--- a/test/clj_progress/core_test.clj
+++ b/test/clj_progress/core_test.clj
@@ -3,6 +3,11 @@
         clojure.test))
 
 
+(defn ainc
+  [^clojure.lang.Atom a]
+  (fn [_] (swap! a inc)))
+
+
 (deftest test-returned-value
   (are [args]
     (binding [*progress-handler* {}]
@@ -69,7 +74,7 @@
     ["baz"   {:q 2}  ]  1)
   (is
     (let [c (atom 0)]
-      (binding [*progress-handler* {:init (fn [_] (swap! c inc))}]
+      (binding [*progress-handler* {:init (ainc c)}]
         (init 123)
         (init 456)
         (= @c 2)))))
@@ -78,7 +83,7 @@
 (deftest test-tick
   (are [h nticks n args]
     (let [c (atom 0)]
-      (binding [*progress-handler*  {:tick (fn [_] (swap! c inc))}
+      (binding [*progress-handler*  {:tick (ainc c)}
                 *progress-state*    (atom {})]
         (init h n)
         (with-throttle 0
@@ -100,7 +105,7 @@
                   (* sleep)
                   (/ throttle)
                   int)]
-      (binding [*progress-handler*  {:tick (fn [_] (swap! c inc))}
+      (binding [*progress-handler*  {:tick (ainc c)}
                 *progress-state*    (atom {})
                 *throttle*          throttle]
         (init n)
@@ -118,7 +123,7 @@
 (deftest test-tick-by
   (are [h bys n args res]
     (let [c (atom 0)]
-      (binding [*progress-handler*  {:tick (fn [_] (swap! c inc))}
+      (binding [*progress-handler*  {:tick (ainc c)}
                 *progress-state*    (atom {})]
         (init h n)
         (with-throttle 0
@@ -140,7 +145,7 @@
 (deftest test-tick-to
   (are [h tos n args res]
     (let [c (atom 0)]
-      (binding [*progress-handler*  {:tick (fn [_] (swap! c inc))}
+      (binding [*progress-handler*  {:tick (ainc c)}
                 *progress-state*    (atom {})]
         (init h n)
         (with-throttle 0
@@ -161,7 +166,7 @@
 (deftest test-done
   (are [args]
     (let [c (atom 0)]
-      (binding [*progress-handler*  {:done (fn [_] (swap! c inc))}
+      (binding [*progress-handler*  {:done (ainc c)}
                 *progress-state*    (atom {})]
         (init "foo" 10)
         (tick)
@@ -176,9 +181,9 @@
   (let [c1 (atom 0)
         c2 (atom 0)
         c3 (atom 0)]
-    (binding [*progress-handler*  { :init (fn [_] (swap! c1 inc))
-                                    :tick (fn [_] (swap! c2 inc))
-                                    :done (fn [_] (swap! c3 inc)) }
+    (binding [*progress-handler*  { :init (ainc c1)
+                                    :tick (ainc c2)
+                                    :done (ainc c3) }
               *progress-state*    (atom {})]
       (with-throttle 0
         (->> (range 50)


### PR DESCRIPTION
When `done` gets a lazy seq as its argument, it throws a `NullPointerException`. The following code can be used to reproduce the error:

```
(use 'clj-progress.core)
(->> [1 2 3]
     (init "Test" 3)
     (map (comp tick inc))
     done)
```

This is the top of the generated stacktrace:

```
java.lang.NullPointerException: null
         Numbers.java:961 clojure.lang.Numbers.ops
         Numbers.java:110 clojure.lang.Numbers.inc
             core.clj:886 clojure.core/inc
             AFn.java:154 clojure.lang.AFn.applyToHelper
             AFn.java:144 clojure.lang.AFn.applyTo
             core.clj:626 clojure.core/apply
            core.clj:5698 clojure.core/update-in
          RestFn.java:445 clojure.lang.RestFn.invoke
             Atom.java:65 clojure.lang.Atom.swap
            core.clj:2234 clojure.core/swap!
              core.clj:59 clj-progress.core/tick
          RestFn.java:408 clojure.lang.RestFn.invoke
            core.clj:2403 clojure.core/comp[fn]
            core.clj:2557 clojure.core/map[fn]
          LazySeq.java:40 clojure.lang.LazySeq.sval
          LazySeq.java:49 clojure.lang.LazySeq.seq
              RT.java:484 clojure.lang.RT.seq
             core.clj:133 clojure.core/seq
```

This likely happens because `done` resets `progress-state`, but the seq is passed through untouched. The seq then gets evaluated at some later point and calls `tick`, but `progress-state` is empty, so incrementing the progress counter fails.

The readme shows a lazy example, but with a reduce, which can be misleading to users. It would be good if it showed that `done` should only be called after evaluating the seq, such as here:

```
(use 'clj-progress.core)
(do
  (doall (->> [1 2 3]
              (init "Test" 3)
              (map (comp tick inc))))
  (done))
```
