### PR TITLE
re-init not working

### DIFF
--- a/src/clj_progress/bar.clj
+++ b/src/clj_progress/bar.clj
@@ -60,6 +60,7 @@
         :total    (if ttl? ttl "?")
         :elapsed  (long elapsed)
         :eta      (cond
+                    (zero? done) "?"
                     done? 0
                     ttl?  (calc-eta ttl done elapsed)
                     :else "?")

--- a/src/clj_progress/core.clj
+++ b/src/clj_progress/core.clj
@@ -39,7 +39,7 @@
 
 (defn re-init
   [ttl]
-  (swap! *progress-state* update-in [:ttl] ttl)
+  (swap! *progress-state* assoc-in [:ttl] ttl)
   (handle :tick))
 
 (defn- tick* [obj]

--- a/test/clj_progress/core_test.clj
+++ b/test/clj_progress/core_test.clj
@@ -81,6 +81,31 @@
         (= @c 2)))))
 
 
+(deftest test-init
+  (binding [*progress-state*   (atom {})
+            *progress-handler* {}]
+    (init 123)
+    (are [n]
+      (do
+        (re-init n)
+        (let [{:keys [ttl done]} @*progress-state*]
+          (and  (= n  ttl)
+                (= 0  done))))
+      123
+      321
+      42))
+  (is
+    (let [c (atom 0)]
+      (binding [*progress-handler* {:init (ainc c)}
+                *progress-state*   (atom {})]
+        (init 123)
+        (re-init 456)
+        (re-init 42)
+        (let [{:keys [ttl]} @*progress-state*]
+          (and  (= 1  @c)
+                (= 42 ttl)))))))
+
+
 (deftest test-tick
   (are [h nticks n args]
     (let [c (atom 0)]


### PR DESCRIPTION
Attempting to change the number of ticks by calling `re-init`as outlined in README.md throws an error:

``` clojure

(progress/init "Processing" 50)
=> 50

(progress/tick)
Processing [=>                                                ] 2% 1/50     => nil

; re-init throws error
(progress/re-init 60)
=> CompilerException java.lang.ClassCastException: java.lang.Long cannot be cast to clojure.lang.IFn
```
