### PR TITLE
Fix throttling names

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Any non-positive value will completely disable throttling.
 
 ## Using custom progress handlers
 
-`clj-proggress` allows you to use your own progress handler by defining `:init`, `:tick` and `:done` hooks with `set-progress-handler!` method or `with-progress-handler` macro:
+`clj-progress` allows you to use your own progress handler by defining `:init`, `:tick` and `:done` hooks with `set-progress-handler!` method or `with-progress-handler` macro:
 
 ```Clojure
 (set-progress-handler!

--- a/README.md
+++ b/README.md
@@ -234,12 +234,12 @@ Indeterminable state also change `:bar` animation.
 `clj-progress` will execute `:tick` progress handler (reprint progress bar, or invoke user-defined handler) as soon as you'll call any `tick` method for the first time.
 If you'll call it again any number of times during the wait period, `:tick` progress handler will not be executed, though progress status will be tracked internally.
 
-You could change default behavior using `set-throttling!` function and `with-throttling` macro:
+You could change default behavior using `set-throttle!` function and `with-throttle` macro:
 
 ```Clojure
-(set-throttling! wait-time-in-milliseconds)
+(set-throttle! wait-time-in-milliseconds)
 
-(with-throttling wait-time-in-milliseconds
+(with-throttle wait-time-in-milliseconds
   (do-something))
 ```
 


### PR DESCRIPTION
They're called `with-throttle/set-throttle!` not `with-throttling/set-throttling!`

https://github.com/Intervox/clj-progress/blob/5669c09397820d823ff8b0a4448dcfdd23910b8c/src/clj_progress/core.clj#L106-L112